### PR TITLE
Control.Monad.Ref: add instance MonadAtomicRef (ST a)

### DIFF
--- a/Control/Monad/Ref.hs
+++ b/Control/Monad/Ref.hs
@@ -225,6 +225,19 @@ instance MonadAtomicRef IO where
     atomicModifyRef' = atomicModifyIORef'
 #endif /* MIN_VERSION_base(4,6,0) */
 
+-- Since there's no forking, it's automatically atomic.
+instance MonadAtomicRef (ST s) where
+    atomicModifyRef r f = do
+      v <- readRef r
+      let (a, b) = f v
+      writeRef r a
+      return b
+    atomicModifyRef' r f = do
+      v <- readRef r
+      let (a, b) = f v
+      writeRef r $! a
+      return b
+
 instance MonadAtomicRef STM where
     atomicModifyRef r f = do x <- readRef r
                              let (x', y) = f x


### PR DESCRIPTION
HNix arrived to the need of this instance.

Details:
  * `Nix.Lint` for `MonadValue (Symbolic m) m` & `newtype Lint s a = Lint`
  * `Nix.Type.Infer` for `MonadAtomicRef (InferT s m)`